### PR TITLE
Fixes spelling errors in comments

### DIFF
--- a/service.rb
+++ b/service.rb
@@ -106,7 +106,7 @@ class Projection
     amount = deposited.amount
     account.deposit(amount)
 
-    # It's impossible to know which even will be received first
+    # It's impossible to know which event will be received first
     # so assign the account ID in every event's projection
     account.id = deposited.account_id
   end
@@ -115,7 +115,7 @@ class Projection
     amount = withdrawn.amount
     account.withdraw(amount)
 
-    # It's impossible to know which even will be received first
+    # It's impossible to know which event will be received first
     # so assign the account ID in every event's projection
     account.id = withdrawn.account_id
   end


### PR DESCRIPTION
Reviewing the domain logic for the basic account demonstration, I happened to notice that the word "event" was misspelled in a comment.

`grep`, run against the working tree for this project, turned up no other candidates for this correction.  